### PR TITLE
Setup proper package installation

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 adversarial-robustness-toolbox[pytorch,tensorflow]==1.6.1
+-e .

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,5 @@ setup(
     url="https://github.com/privML/privacy-evaluator",
     license="MIT",
     packages=["privacy_evaluator"],
-    install_requires=[
-        "adversarial-robustness-toolbox[pytorch,tensorflow]==1.6.1"
-    ]
+    install_requires=["adversarial-robustness-toolbox[pytorch,tensorflow]==1.6.1"],
 )

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,13 @@
+from setuptools import setup
+
+setup(
+    name="privacy-evaluator",
+    version="0.1",
+    description="Tool to assess ML model's levels of privacy.",
+    url="https://github.com/privML/privacy-evaluator",
+    license="MIT",
+    packages=["privacy_evaluator"],
+    install_requires=[
+        "adversarial-robustness-toolbox[pytorch,tensorflow]==1.6.1"
+    ]
+)


### PR DESCRIPTION
This solves issue #73. 

I added setup files for this package. I followed this guide: [python-packaging](https://python-packaging.readthedocs.io/en/latest/). You can now easily install the `privacy-evaluator` with running `pip install -r requirements` or `pip install -e .`.