### PR TITLE
Fix/team2sprint4

### DIFF
--- a/privacy_evaluator/attacks/property_inference_attack.py
+++ b/privacy_evaluator/attacks/property_inference_attack.py
@@ -10,7 +10,6 @@ import numpy as np
 import torch
 from torch import nn
 import tensorflow as tf
-from sklearn.model_selection import train_test_split
 from tqdm import tqdm
 import sys
 from typing import Tuple, Dict, List, Union
@@ -165,12 +164,7 @@ class PropertyInferenceAttack(Attack):
         for shadow_training_set in tqdm(
             shadow_training_sets, file=sys.stdout, disable=(self.verbose < 2)
         ):
-            shadow_training_X, shadow_training_y = shadow_training_set
-            train_X, test_X, train_y, test_y = train_test_split(
-                shadow_training_X, shadow_training_y, test_size=0.3
-            )
-            train_set = (train_X, train_y)
-            test_set = (test_X, test_y)
+            train_set = shadow_training_set
 
             model = copy_and_reset_model(self.target_model)
             trainer(train_set, num_elements_per_classes, model, verbose=self.verbose)

--- a/privacy_evaluator/attacks/property_inference_attack.py
+++ b/privacy_evaluator/attacks/property_inference_attack.py
@@ -164,10 +164,13 @@ class PropertyInferenceAttack(Attack):
         for shadow_training_set in tqdm(
             shadow_training_sets, file=sys.stdout, disable=(self.verbose < 2)
         ):
-            train_set = shadow_training_set
-
             model = copy_and_reset_model(self.target_model)
-            trainer(train_set, num_elements_per_classes, model, verbose=self.verbose)
+            trainer(
+                shadow_training_set,
+                num_elements_per_classes,
+                model,
+                verbose=self.verbose,
+            )
 
             # change pytorch classifier to art classifier
             art_model = Classifier._to_art_classifier(


### PR DESCRIPTION
Remove redundant split procedure when preparing data for shadow classifiers. This problem has already been resolved during Sprint 2 but recovered maybe from merging code from Team 1 where our old "wrong" code still stays in their branch.