### PR TITLE
#192 #193 #197

### DIFF
--- a/notebooks/membership_inference_black_box_attack.ipynb
+++ b/notebooks/membership_inference_black_box_attack.ipynb
@@ -2,7 +2,6 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "Rf_QO8flWx6_",
    "metadata": {
     "id": "Rf_QO8flWx6_"
    },
@@ -12,7 +11,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "WKAYn2M4Wx7F",
    "metadata": {
     "id": "WKAYn2M4Wx7F"
    },
@@ -29,7 +27,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "Ia0VmlzeWx7H",
    "metadata": {
     "id": "Ia0VmlzeWx7H"
    },
@@ -41,7 +38,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "DH6rB9KSWx7J",
    "metadata": {
     "id": "DH6rB9KSWx7J"
    },
@@ -54,7 +50,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "lNU7L3GCWx7M",
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/"
@@ -70,7 +65,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9d7ab468",
    "metadata": {
     "id": "9d7ab468"
    },
@@ -102,7 +96,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "mUH4YQ4tWx7Q",
    "metadata": {
     "id": "mUH4YQ4tWx7Q"
    },
@@ -114,7 +107,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b2da0876",
    "metadata": {
     "id": "b2da0876"
    },
@@ -126,7 +118,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "7aQIN6UMWx7W",
    "metadata": {
     "id": "7aQIN6UMWx7W"
    },
@@ -139,7 +130,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "fz4UuSxMWx7Y",
    "metadata": {
     "id": "fz4UuSxMWx7Y"
    },
@@ -156,7 +146,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "sv_fGg8jWx7S",
    "metadata": {
     "id": "sv_fGg8jWx7S"
    },
@@ -169,7 +158,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "dcae11d8",
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/"
@@ -185,7 +173,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c7761c0c",
    "metadata": {
     "id": "c7761c0c"
    },
@@ -198,7 +185,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "cd9e4799",
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/"
@@ -215,7 +201,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "5770d67d",
    "metadata": {
     "id": "5770d67d"
    },
@@ -228,7 +213,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "8eaa9ed6",
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/",
@@ -254,25 +238,23 @@
   },
   {
    "cell_type": "markdown",
-   "id": "dRPu6e955n_B",
    "metadata": {
     "id": "dRPu6e955n_B"
    },
    "source": [
     "#### Explanation of the outcome:\n",
     "\n",
-    "Attack Model Accuracy:\n",
-    "The attack model accuracy specifies how well the membership attack model performs in predicting if a given data point was used for training the target model. Since we have a two-class classification problem that the attack model solves (member or non-member), the lowest possible accuracy is 50% (random guessing for each sample). The best accuracy is at 100% if the model predicts every data point is sees right as member or non-member.\n",
+    "##### Attack Model Accuracy:\n",
+    "The attack model accuracy specifies how well the membership attack model performs in predicting if a given data point was used for training the target model. Since we have a two-class classification problem that the attack model solves (member or non-member), the lowest possible accuracy is 50%, which is equal to randomly guessing the class of a sample.  Theoretically, accuracy can also go below 50%, down to 0%. In this case, an inversion of the prediction of the labels can yield better results. E.g. if the accuracy is 40%, an inversion of the predicted labels yields 60% accuracy, hence 50% is considered the worst, or lowest possible accuracy. The best accuracy is at 100% if the model predicts every data point is sees right as member or non-member.\n",
     "\n",
-    "Train-Test-Gap (difference):\n",
+    "##### Train-Test-Gap (difference):\n",
     "If your model has a train-test-gap larger than 5%, this could be a sign that your model overfits. Overfitting can be beneficial for successful membership inference attacks [1]. Therefore, you might want to reduce it by introducing regularization methods in your training, or using specific privacy methods [2,3], such as Differential Privacy [4].\n",
     "\n",
-    "(For References, please see last box)"
+    "(For References, please see last box)\n"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "fpycszf2JBfw",
    "metadata": {
     "id": "fpycszf2JBfw"
    },
@@ -285,7 +267,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "h7CAm0_aJD05",
    "metadata": {
     "id": "h7CAm0_aJD05"
    },
@@ -304,20 +285,30 @@
   },
   {
    "cell_type": "markdown",
-   "id": "H52Z0hJyJHj6",
    "metadata": {
     "id": "H52Z0hJyJHj6"
    },
    "source": [
     "#### Define the slicing\n",
     "\n",
-    "Now we can define the slicing for our analysis. The slicing defines how the data will be sliced. Each slice will then be analysed by the attack separately, so see if the inference works better on certain parts of data than on others. "
+    "Now we can define the slicing for our analysis. The slicing defines how the data will be sliced. Each slice will then be analysed by the attack separately, so see if the inference works better on certain parts of data than on others.\n",
+    "\n",
+    "The types of slices can be chosen:\n",
+    "##### entire_dataset:\n",
+    "This options allows to pick the whole dataset as a single slice.\n",
+    "##### by_class:\n",
+    "If this option is chosen, the analysis will be done for each class individually, resulting in as many slices as there are classes.\n",
+    "##### by_classification_correctness:\n",
+    "If this option is chosen, two slices will be analyzed. The first slice is the set of all correctly classified samples, and the second slice is the set of all incorrectly classified samples.\n",
+    "\n",
+    "If all three choices are selected, a total of 3 + n slices will be analyzed, where n is the amount of classes of the dataset.\n",
+    "\n",
+    "For further information, please see the explanation of the outcome below the analysis."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "Gk9F4EiCJJGq",
    "metadata": {
     "id": "Gk9F4EiCJJGq"
    },
@@ -332,7 +323,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "yUEf6yXOJLUm",
    "metadata": {
     "id": "yUEf6yXOJLUm"
    },
@@ -345,7 +335,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "AUTnIKUEJM8R",
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/"
@@ -369,7 +358,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "K5yIBZEGJQxi",
    "metadata": {
     "id": "K5yIBZEGJQxi"
    },
@@ -394,7 +382,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "xG4nYKGzWx7i",
    "metadata": {
     "id": "xG4nYKGzWx7i"
    },
@@ -406,7 +393,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "_7ty54AKWx7k",
    "metadata": {
     "id": "_7ty54AKWx7k"
    },
@@ -419,7 +405,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "Uhrn5znOWx7k",
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/"
@@ -440,7 +425,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "UBfeudg_Wx7i",
    "metadata": {
     "id": "UBfeudg_Wx7i"
    },
@@ -453,7 +437,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "kAJgfSgoWx7j",
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/"
@@ -469,7 +452,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "mLC_hmb8Wx7l",
    "metadata": {
     "id": "mLC_hmb8Wx7l"
    },
@@ -482,7 +464,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "QLddiPbkWx7l",
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/"
@@ -499,7 +480,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "bnE8ETvRWx7m",
    "metadata": {
     "id": "bnE8ETvRWx7m"
    },
@@ -512,7 +492,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "ysx92hInWx7n",
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/",
@@ -538,17 +517,16 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ZnNgIXJC7ppu",
    "metadata": {
     "id": "ZnNgIXJC7ppu"
    },
    "source": [
     "#### Explanation of the outcome:\n",
     "\n",
-    "Attack Model Accuracy:\n",
-    "The attack model accuracy specifies how well the membership attack model performs in predicting if a given data point was used for training the target model. Since we have a two-class classification problem that the attack model solves (member or non-member), the lowest possible accuracy is 50% (random guessing for each sample). The best accuracy is at 100% if the model predicts every data point is sees right as member or non-member.\n",
+    "##### Attack Model Accuracy:\n",
+    "The attack model accuracy specifies how well the membership attack model performs in predicting if a given data point was used for training the target model. Since we have a two-class classification problem that the attack model solves (member or non-member), the lowest possible accuracy is 50%, which is equal to randomly guessing the class of a sample.  Theoretically, accuracy can also go below 50%, down to 0%. In this case, an inversion of the prediction of the labels can yield better results. E.g. if the accuracy is 40%, an inversion of the predicted labels yields 60% accuracy, hence 50% is considered the worst, or lowest possible accuracy. The best accuracy is at 100% if the model predicts every data point is sees right as member or non-member.\n",
     "\n",
-    "Train-Test-Gap (difference):\n",
+    "##### Train-Test-Gap (difference):\n",
     "If your model has a train-test-gap larger than 5%, this could be a sign that your model overfits. Overfitting can be beneficial for successful membership inference attacks [1]. Therefore, you might want to reduce it by introducing regularization methods in your training, or using specific privacy methods [2,3], such as Differential Privacy [4].\n",
     "\n",
     "(For References, please see last box)\n"
@@ -556,7 +534,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "mrnYkSK0JqNs",
    "metadata": {
     "id": "mrnYkSK0JqNs"
    },
@@ -569,7 +546,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "gEyz9CDkJr1Z",
    "metadata": {
     "id": "gEyz9CDkJr1Z"
    },
@@ -588,20 +564,30 @@
   },
   {
    "cell_type": "markdown",
-   "id": "9UEL4XUBJtUP",
    "metadata": {
     "id": "9UEL4XUBJtUP"
    },
    "source": [
     "#### Define the slicing\n",
     "\n",
-    "Now we can define the slicing for our analysis. The slicing defines how the data will be sliced. Each slice will then be analysed by the attack separately, so see if the inference works better on certain parts of data than on others. "
+    "Now we can define the slicing for our analysis. The slicing defines how the data will be sliced. Each slice will then be analysed by the attack separately, so see if the inference works better on certain parts of data than on others.\n",
+    "\n",
+    "The types of slices can be chosen:\n",
+    "##### entire_dataset:\n",
+    "This options allows to pick the whole dataset as a single slice.\n",
+    "##### by_class:\n",
+    "If this option is chosen, the analysis will be done for each class individually, resulting in as many slices as there are classes.\n",
+    "##### by_classification_correctness:\n",
+    "If this option is chosen, two slices will be analyzed. The first slice is the set of all correctly classified samples, and the second slice is the set of all incorrectly classified samples.\n",
+    "\n",
+    "If all three choices are selected, a total of 3 + n slices will be analyzed, where n is the amount of classes of the dataset.\n",
+    "\n",
+    "For further information, please see the explanation of the outcome below the analysis."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "YeGUtkbKJvmv",
    "metadata": {
     "id": "YeGUtkbKJvmv"
    },
@@ -616,7 +602,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "cT3cZVFFJxJq",
    "metadata": {
     "id": "cT3cZVFFJxJq"
    },
@@ -629,7 +614,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "gFQuFLedJzEo",
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/"
@@ -653,7 +637,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "V9n1Y1AuJ0YY",
    "metadata": {
     "id": "V9n1Y1AuJ0YY"
    },
@@ -678,7 +661,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "DmyWRprb842M",
    "metadata": {
     "id": "DmyWRprb842M"
    },
@@ -693,24 +675,8 @@
     "\n",
     "[5] Stacey Truex, Ling Liu, Mehmet Emre Gursoy, Lei Yu, and Wenqi Wei. 2019.Demystifying Membership Inference Attacks in Machine Learning as a Service.IEEE Transactions on Services Computing(2019)\n",
     "\n",
-    "[6] Suriyakumar, Vinith M., Nicolas Papernot, Anna Goldenberg, and Marzyeh Ghassemi. \"Chasing Your Long Tails: Differentially Private Prediction in Health Care Settings.\" In Proceedings of the 2021 ACM Conference on Fairness, Accountability, and Transparency, pp. 723-734. 2021.\n",
-    "\n",
-    "[7] Yunhui Long, Vincent Bindschaedler, Lei Wang, Diyue Bu, Xiaofeng Wang, HaixuTang, Carl A. Gunter, and Kai Chen. 2018.   Understanding Membership In-ferences on Well-Generalized Learning Models.CoRRabs/1802.04889 (2018).arXiv:1802.04889  http://arxiv.org/abs/1802.0\n"
+    "[6] Suriyakumar, Vinith M., Nicolas Papernot, Anna Goldenberg, and Marzyeh Ghassemi. \"Chasing Your Long Tails: Differentially Private Prediction in Health Care Settings.\" In Proceedings of the 2021 ACM Conference on Fairness, Accountability, and Transparency, pp. 723-734. 2021."
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {
@@ -738,7 +704,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.10"
+   "version": "3.8.5"
   }
  },
  "nbformat": 4,

--- a/notebooks/membership_inference_black_box_rule_based_attack.ipynb
+++ b/notebooks/membership_inference_black_box_rule_based_attack.ipynb
@@ -2,7 +2,6 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "Rf_QO8flWx6_",
    "metadata": {
     "id": "Rf_QO8flWx6_"
    },
@@ -12,7 +11,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "WKAYn2M4Wx7F",
    "metadata": {
     "id": "WKAYn2M4Wx7F"
    },
@@ -29,7 +27,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "Ia0VmlzeWx7H",
    "metadata": {
     "id": "Ia0VmlzeWx7H"
    },
@@ -42,7 +39,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "DH6rB9KSWx7J",
    "metadata": {
     "id": "DH6rB9KSWx7J"
    },
@@ -55,7 +51,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "lNU7L3GCWx7M",
    "metadata": {
     "id": "lNU7L3GCWx7M"
    },
@@ -67,7 +62,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9d7ab468",
    "metadata": {
     "id": "9d7ab468"
    },
@@ -99,7 +93,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "mUH4YQ4tWx7Q",
    "metadata": {
     "id": "mUH4YQ4tWx7Q"
    },
@@ -111,7 +104,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b2da0876",
    "metadata": {
     "id": "b2da0876"
    },
@@ -123,7 +115,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "7aQIN6UMWx7W",
    "metadata": {
     "id": "7aQIN6UMWx7W"
    },
@@ -136,7 +127,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "fz4UuSxMWx7Y",
    "metadata": {
     "id": "fz4UuSxMWx7Y"
    },
@@ -153,7 +143,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "sv_fGg8jWx7S",
    "metadata": {
     "id": "sv_fGg8jWx7S"
    },
@@ -166,7 +155,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "dcae11d8",
    "metadata": {
     "id": "dcae11d8"
    },
@@ -178,7 +166,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "76a432f6",
    "metadata": {
     "id": "76a432f6"
    },
@@ -191,7 +178,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "35c9fc67",
    "metadata": {
     "id": "35c9fc67"
    },
@@ -203,7 +189,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f4ecb6b3",
    "metadata": {
     "id": "f4ecb6b3"
    },
@@ -216,7 +201,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "274272d3",
    "metadata": {
     "id": "274272d3"
    },
@@ -237,7 +221,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "IxquXY0x8CF_",
    "metadata": {
     "id": "IxquXY0x8CF_"
    },
@@ -245,12 +228,11 @@
     "#### Explanation of the outcome:\n",
     "\n",
     "##### Attack Model Accuracy:\n",
-    "The attack model accuracy specifies how well the membership attack model performs in predicting if a given data point was used for training the target model. Since we have a two-class classification problem that the attack model solves (member or non-member), the lowest possible accuracy is 50% (random guessing for each sample). The best accuracy is at 100% if the model predicts every data point is sees right as member or non-member."
+    "The attack model accuracy specifies how well the membership attack model performs in predicting if a given data point was used for training the target model. Since we have a two-class classification problem that the attack model solves (member or non-member), the lowest possible accuracy is 50%, which is equal to randomly guessing the class of a sample.  Theoretically, accuracy can also go below 50%, down to 0%. In this case, an inversion of the prediction of the labels can yield better results. E.g. if the accuracy is 40%, an inversion of the predicted labels yields 60% accuracy, hence 50% is considered the worst, or lowest possible accuracy. The best accuracy is at 100% if the model predicts every data point is sees right as member or non-member."
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "9Ka1UONoDFlY",
    "metadata": {
     "id": "9Ka1UONoDFlY"
    },
@@ -263,7 +245,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "aE3cakPzDmBd",
    "metadata": {
     "id": "aE3cakPzDmBd"
    },
@@ -282,20 +263,30 @@
   },
   {
    "cell_type": "markdown",
-   "id": "AK8vw9v-Dm7G",
    "metadata": {
     "id": "AK8vw9v-Dm7G"
    },
    "source": [
     "#### Define the slicing\n",
     "\n",
-    "Now we can define the slicing for our analysis. The slicing defines how the data will be sliced. Each slice will then be analysed by the attack separately, so see if the inference works better on certain parts of data than on others. "
+    "Now we can define the slicing for our analysis. The slicing defines how the data will be sliced. Each slice will then be analysed by the attack separately, so see if the inference works better on certain parts of data than on others.\n",
+    "\n",
+    "The types of slices can be chosen:\n",
+    "##### entire_dataset:\n",
+    "This options allows to pick the whole dataset as a single slice.\n",
+    "##### by_class:\n",
+    "If this option is chosen, the analysis will be done for each class individually, resulting in as many slices as there are classes.\n",
+    "##### by_classification_correctness:\n",
+    "If this option is chosen, two slices will be analyzed. The first slice is the set of all correctly classified samples, and the second slice is the set of all incorrectly classified samples.\n",
+    "\n",
+    "If all three choices are selected, a total of 3 + n slices will be analyzed, where n is the amount of classes of the dataset.\n",
+    "\n",
+    "For further information, please see the explanation of the outcome below the analysis."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "59Z9WVRaDoIb",
    "metadata": {
     "id": "59Z9WVRaDoIb"
    },
@@ -310,7 +301,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "XdavMRYlDp35",
    "metadata": {
     "id": "XdavMRYlDp35"
    },
@@ -323,7 +313,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "pdsW4uNcDrkU",
    "metadata": {
     "id": "pdsW4uNcDrkU",
     "scrolled": false
@@ -343,7 +332,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "A6NNaOOfDvCk",
    "metadata": {
     "id": "A6NNaOOfDvCk"
    },
@@ -358,9 +346,9 @@
     "It is normal that the attacker is more successful to deduce membership on incorrectly classified samples than on correctly classified ones. This results from the fact, that model predictions are often better on training than on test data points, whereby your attack model might learn to predict incorrectly classified samples as non-members. If your model overfits the training data, this assumption might hold true often enough to make the attack seem more successful on this slice. If you wish to reduce that, pay attention to reducing your model’s overfitting.\n",
     "\n",
     "##### Slicing: Specific classes more vulnerable: \n",
-    "It seems that the membership inference attack is more successful on your class X than on the other classes. Research has shown that the class distribution (and also the distribution of data points within one class) are factors that influence the vulnerability of a class for membership inference attacks [5].\n",
+    "It seems that the membership inference attack is more successful on your class X than on the other classes. Research has shown that the class distribution (and also the distribution of data points within one class) are factors that influence the vulnerability of a class for membership inference attacks [1].\n",
     "\n",
-    "Also, small classes (belonging to minority groups) can be more prone to membership inference attacks [6]. One reason for this could be, that there is less data for that class, and therefore, the model overfits within this class. It might make sense to look into the vulnerable classes of your model again, and maybe add more data to them, use private synthetic data, or introduce privacy methods like Differential Privacy [6]. Attention, the use of Differential Privacy could have a negative influence on the performance of your model for the minority classes.\n",
+    "Also, small classes (belonging to minority groups) can be more prone to membership inference attacks [2]. One reason for this could be, that there is less data for that class, and therefore, the model overfits within this class. It might make sense to look into the vulnerable classes of your model again, and maybe add more data to them, use private synthetic data, or introduce privacy methods like Differential Privacy [2]. Attention, the use of Differential Privacy could have a negative influence on the performance of your model for the minority classes.\n",
     "\n",
     "\n",
     "(For References, please see last box)"
@@ -368,7 +356,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "xG4nYKGzWx7i",
    "metadata": {
     "id": "xG4nYKGzWx7i"
    },
@@ -380,7 +367,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "_7ty54AKWx7k",
    "metadata": {
     "id": "_7ty54AKWx7k"
    },
@@ -393,7 +379,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "Uhrn5znOWx7k",
    "metadata": {
     "id": "Uhrn5znOWx7k"
    },
@@ -410,7 +395,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "UBfeudg_Wx7i",
    "metadata": {
     "id": "UBfeudg_Wx7i"
    },
@@ -423,7 +407,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "kAJgfSgoWx7j",
    "metadata": {
     "id": "kAJgfSgoWx7j"
    },
@@ -435,7 +418,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "VMOD4MsfWx7o",
    "metadata": {
     "id": "VMOD4MsfWx7o"
    },
@@ -448,7 +430,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "M6q1WZSAWx7p",
    "metadata": {
     "id": "M6q1WZSAWx7p"
    },
@@ -460,7 +441,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "8_K4-ErBWx7q",
    "metadata": {
     "id": "8_K4-ErBWx7q"
    },
@@ -473,7 +453,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "qY4g4xHZWx7q",
    "metadata": {
     "id": "qY4g4xHZWx7q"
    },
@@ -494,7 +473,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "pa-PyGbB8A35",
    "metadata": {
     "id": "pa-PyGbB8A35"
    },
@@ -502,12 +480,11 @@
     "#### Explanation of the outcome:\n",
     "\n",
     "##### Attack Model Accuracy:\n",
-    "The attack model accuracy specifies how well the membership attack model performs in predicting if a given data point was used for training the target model. Since we have a two-class classification problem that the attack model solves (member or non-member), the lowest possible accuracy is 50% (random guessing for each sample). The best accuracy is at 100% if the model predicts every data point is sees right as member or non-member."
+    "The attack model accuracy specifies how well the membership attack model performs in predicting if a given data point was used for training the target model. Since we have a two-class classification problem that the attack model solves (member or non-member), the lowest possible accuracy is 50%, which is equal to randomly guessing the class of a sample.  Theoretically, accuracy can also go below 50%, down to 0%. In this case, an inversion of the prediction of the labels can yield better results. E.g. if the accuracy is 40%, an inversion of the predicted labels yields 60% accuracy, hence 50% is considered the worst, or lowest possible accuracy. The best accuracy is at 100% if the model predicts every data point is sees right as member or non-member."
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "GTUIFR5gDJ4Z",
    "metadata": {
     "id": "GTUIFR5gDJ4Z"
    },
@@ -520,7 +497,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "Cldis2weDMI-",
    "metadata": {
     "id": "Cldis2weDMI-"
    },
@@ -539,20 +515,30 @@
   },
   {
    "cell_type": "markdown",
-   "id": "7QL_9rSDDNkG",
    "metadata": {
     "id": "7QL_9rSDDNkG"
    },
    "source": [
     "#### Define the slicing\n",
     "\n",
-    "Now we can define the slicing for our analysis. The slicing defines how the data will be sliced. Each slice will then be analysed by the attack separately, so see if the inference works better on certain parts of data than on others. "
+    "Now we can define the slicing for our analysis. The slicing defines how the data will be sliced. Each slice will then be analysed by the attack separately, so see if the inference works better on certain parts of data than on others.\n",
+    "\n",
+    "The types of slices can be chosen:\n",
+    "##### entire_dataset:\n",
+    "This options allows to pick the whole dataset as a single slice.\n",
+    "##### by_class:\n",
+    "If this option is chosen, the analysis will be done for each class individually, resulting in as many slices as there are classes.\n",
+    "##### by_classification_correctness:\n",
+    "If this option is chosen, two slices will be analyzed. The first slice is the set of all correctly classified samples, and the second slice is the set of all incorrectly classified samples.\n",
+    "\n",
+    "If all three choices are selected, a total of 3 + n slices will be analyzed, where n is the amount of classes of the dataset.\n",
+    "\n",
+    "For further information, please see the explanation of the outcome below the analysis."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "Dp_TlL9XDQK1",
    "metadata": {
     "id": "Dp_TlL9XDQK1"
    },
@@ -567,7 +553,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "u7_B_FWkDR5D",
    "metadata": {
     "id": "u7_B_FWkDR5D"
    },
@@ -580,7 +565,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "Cc_DLnPODVOP",
    "metadata": {
     "id": "Cc_DLnPODVOP"
    },
@@ -599,7 +583,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "nLlQkyZYDaFo",
    "metadata": {
     "id": "nLlQkyZYDaFo"
    },
@@ -614,9 +597,9 @@
     "It is normal that the attacker is more successful to deduce membership on incorrectly classified samples than on correctly classified ones. This results from the fact, that model predictions are often better on training than on test data points, whereby your attack model might learn to predict incorrectly classified samples as non-members. If your model overfits the training data, this assumption might hold true often enough to make the attack seem more successful on this slice. If you wish to reduce that, pay attention to reducing your model’s overfitting.\n",
     "\n",
     "##### Slicing: Specific classes more vulnerable: \n",
-    "It seems that the membership inference attack is more successful on your class X than on the other classes. Research has shown that the class distribution (and also the distribution of data points within one class) are factors that influence the vulnerability of a class for membership inference attacks [5].\n",
+    "It seems that the membership inference attack is more successful on your class X than on the other classes. Research has shown that the class distribution (and also the distribution of data points within one class) are factors that influence the vulnerability of a class for membership inference attacks [1].\n",
     "\n",
-    "Also, small classes (belonging to minority groups) can be more prone to membership inference attacks [6]. One reason for this could be, that there is less data for that class, and therefore, the model overfits within this class. It might make sense to look into the vulnerable classes of your model again, and maybe add more data to them, use private synthetic data, or introduce privacy methods like Differential Privacy [6]. Attention, the use of Differential Privacy could have a negative influence on the performance of your model for the minority classes.\n",
+    "Also, small classes (belonging to minority groups) can be more prone to membership inference attacks [2]. One reason for this could be, that there is less data for that class, and therefore, the model overfits within this class. It might make sense to look into the vulnerable classes of your model again, and maybe add more data to them, use private synthetic data, or introduce privacy methods like Differential Privacy [2]. Attention, the use of Differential Privacy could have a negative influence on the performance of your model for the minority classes.\n",
     "\n",
     "\n",
     "(For References, please see last box)"
@@ -624,35 +607,14 @@
   },
   {
    "cell_type": "markdown",
-   "id": "LjKjKcOtFple",
    "metadata": {
     "id": "LjKjKcOtFple"
    },
    "source": [
-    "[1]S. Yeom, I. Giacomelli, M. Fredrikson, and S. Jha. \\Privacy Risk in Machine Learning: Analyzing the Connection to Overfitting\". In: 2018 IEEE 31st Computer Security Foundations Symposium (CSF). July 2018, pp. 268{282. doi:10.1109/CSF.2018.00027.\n",
+    "[1] Stacey Truex, Ling Liu, Mehmet Emre Gursoy, Lei Yu, and Wenqi Wei. 2019.Demystifying Membership Inference Attacks in Machine Learning as a Service.IEEE Transactions on Services Computing(2019)\n",
     "\n",
-    "[2] Reza Shokri, Marco Stronati, Congzheng Song, and Vitaly Shmatikov. 2017. Mem-bership Inference Attacks Against Machine Learning Models. In2017 IEEE Sym-posium on Security and Privacy (SP). 3–18.\n",
-    "\n",
-    "[3] Milad Nasr, Reza Shokri, and Amir Houmansadr. 2018. Machine Learning withMembership Privacy Using Adversarial Regularization. InProceedings of the 2018ACM SIGSAC Conference on Computer and Communications Security(Toronto,Canada)(CCS ’18). Association for Computing Machinery, New York, NY, USA,634–64\n",
-    "\n",
-    "[4] Cynthia Dwork. 2006.  Differential Privacy. InAutomata, Languages and Pro-gramming, Michele Bugliesi, Bart Preneel, Vladimiro Sassone, and Ingo Wegener(Eds.). Springer Berlin Heidelberg, Berlin, Heidelberg\n",
-    "\n",
-    "[5] Stacey Truex, Ling Liu, Mehmet Emre Gursoy, Lei Yu, and Wenqi Wei. 2019.Demystifying Membership Inference Attacks in Machine Learning as a Service.IEEE Transactions on Services Computing(2019)\n",
-    "\n",
-    "[6] Suriyakumar, Vinith M., Nicolas Papernot, Anna Goldenberg, and Marzyeh Ghassemi. \"Chasing Your Long Tails: Differentially Private Prediction in Health Care Settings.\" In Proceedings of the 2021 ACM Conference on Fairness, Accountability, and Transparency, pp. 723-734. 2021.\n",
-    "\n",
-    "[7] Yunhui Long, Vincent Bindschaedler, Lei Wang, Diyue Bu, Xiaofeng Wang, HaixuTang, Carl A. Gunter, and Kai Chen. 2018.   Understanding Membership In-ferences on Well-Generalized Learning Models.CoRRabs/1802.04889 (2018).arXiv:1802.04889  http://arxiv.org/abs/1802.0\n"
+    "[2] Suriyakumar, Vinith M., Nicolas Papernot, Anna Goldenberg, and Marzyeh Ghassemi. \"Chasing Your Long Tails: Differentially Private Prediction in Health Care Settings.\" In Proceedings of the 2021 ACM Conference on Fairness, Accountability, and Transparency, pp. 723-734. 2021."
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "V2w1YZGEFqH5",
-   "metadata": {
-    "id": "V2w1YZGEFqH5"
-   },
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {
@@ -680,7 +642,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.10"
+   "version": "3.8.5"
   }
  },
  "nbformat": 4,

--- a/notebooks/membership_inference_label_only_decision_boundary_attack.ipynb
+++ b/notebooks/membership_inference_label_only_decision_boundary_attack.ipynb
@@ -2,7 +2,6 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "Rf_QO8flWx6_",
    "metadata": {
     "id": "Rf_QO8flWx6_"
    },
@@ -12,7 +11,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "WKAYn2M4Wx7F",
    "metadata": {
     "id": "WKAYn2M4Wx7F"
    },
@@ -29,7 +27,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "Ia0VmlzeWx7H",
    "metadata": {
     "id": "Ia0VmlzeWx7H"
    },
@@ -42,7 +39,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "DH6rB9KSWx7J",
    "metadata": {
     "id": "DH6rB9KSWx7J"
    },
@@ -55,7 +51,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "lNU7L3GCWx7M",
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/"
@@ -71,7 +66,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9d7ab468",
    "metadata": {
     "id": "9d7ab468"
    },
@@ -103,7 +97,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "mUH4YQ4tWx7Q",
    "metadata": {
     "id": "mUH4YQ4tWx7Q"
    },
@@ -115,7 +108,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b2da0876",
    "metadata": {
     "id": "b2da0876"
    },
@@ -127,7 +119,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "7aQIN6UMWx7W",
    "metadata": {
     "id": "7aQIN6UMWx7W"
    },
@@ -140,7 +131,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "fz4UuSxMWx7Y",
    "metadata": {
     "id": "fz4UuSxMWx7Y"
    },
@@ -157,7 +147,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "sv_fGg8jWx7S",
    "metadata": {
     "id": "sv_fGg8jWx7S"
    },
@@ -170,7 +159,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "dcae11d8",
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/",
@@ -197,7 +185,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ee10af5d",
    "metadata": {
     "id": "ee10af5d"
    },
@@ -210,7 +197,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "73278928",
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/",
@@ -254,7 +240,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "0e0b5639",
    "metadata": {
     "id": "0e0b5639"
    },
@@ -267,7 +252,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "ec3551f5",
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/",
@@ -303,17 +287,16 @@
   },
   {
    "cell_type": "markdown",
-   "id": "VcyzBkd39Y-a",
    "metadata": {
     "id": "VcyzBkd39Y-a"
    },
    "source": [
     "#### Explanation of the outcome:\n",
     "\n",
-    "Attack Model Accuracy:\n",
-    "The attack model accuracy specifies how well the membership attack model performs in predicting if a given data point was used for training the target model. Since we have a two-class classification problem that the attack model solves (member or non-member), the lowest possible accuracy is 50% (random guessing for each sample). The best accuracy is at 100% if the model predicts every data point is sees right as member or non-member.\n",
+    "##### Attack Model Accuracy:\n",
+    "The attack model accuracy specifies how well the membership attack model performs in predicting if a given data point was used for training the target model. Since we have a two-class classification problem that the attack model solves (member or non-member), the lowest possible accuracy is 50%, which is equal to randomly guessing the class of a sample.  Theoretically, accuracy can also go below 50%, down to 0%. In this case, an inversion of the prediction of the labels can yield better results. E.g. if the accuracy is 40%, an inversion of the predicted labels yields 60% accuracy, hence 50% is considered the worst, or lowest possible accuracy. The best accuracy is at 100% if the model predicts every data point is sees right as member or non-member.\n",
     "\n",
-    "Train-Test-Gap (difference):\n",
+    "##### Train-Test-Gap (difference):\n",
     "If your model has a train-test-gap larger than 5%, this could be a sign that your model overfits. Overfitting can be beneficial for successful membership inference attacks [1]. Therefore, you might want to reduce it by introducing regularization methods in your training, or using specific privacy methods [2,3], such as Differential Privacy [4].\n",
     "\n",
     "(For References, please see last box)"
@@ -321,7 +304,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "wg91lAQ5Kqru",
    "metadata": {
     "id": "wg91lAQ5Kqru"
    },
@@ -334,7 +316,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "cIFO6E8JLKZq",
    "metadata": {
     "id": "cIFO6E8JLKZq"
    },
@@ -353,20 +334,30 @@
   },
   {
    "cell_type": "markdown",
-   "id": "HNAKAwE1LVrK",
    "metadata": {
     "id": "HNAKAwE1LVrK"
    },
    "source": [
     "#### Define the slicing\n",
     "\n",
-    "Now we can define the slicing for our analysis. The slicing defines how the data will be sliced. Each slice will then be analysed by the attack separately, so see if the inference works better on certain parts of data than on others. "
+    "Now we can define the slicing for our analysis. The slicing defines how the data will be sliced. Each slice will then be analysed by the attack separately, so see if the inference works better on certain parts of data than on others.\n",
+    "\n",
+    "The types of slices can be chosen:\n",
+    "##### entire_dataset:\n",
+    "This options allows to pick the whole dataset as a single slice.\n",
+    "##### by_class:\n",
+    "If this option is chosen, the analysis will be done for each class individually, resulting in as many slices as there are classes.\n",
+    "##### by_classification_correctness:\n",
+    "If this option is chosen, two slices will be analyzed. The first slice is the set of all correctly classified samples, and the second slice is the set of all incorrectly classified samples.\n",
+    "\n",
+    "If all three choices are selected, a total of 3 + n slices will be analyzed, where n is the amount of classes of the dataset.\n",
+    "\n",
+    "For further information, please see the explanation of the outcome below the analysis."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "KTnov_yTLZ0U",
    "metadata": {
     "id": "KTnov_yTLZ0U"
    },
@@ -381,7 +372,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "xiyv0m64Lbcu",
    "metadata": {
     "id": "xiyv0m64Lbcu"
    },
@@ -394,7 +384,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "3d0wiDYQLegJ",
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/",
@@ -444,7 +433,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "I_f_Hk7hLt3v",
    "metadata": {
     "id": "I_f_Hk7hLt3v"
    },
@@ -469,7 +457,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "xG4nYKGzWx7i",
    "metadata": {
     "id": "xG4nYKGzWx7i"
    },
@@ -481,7 +468,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "_7ty54AKWx7k",
    "metadata": {
     "id": "_7ty54AKWx7k"
    },
@@ -494,7 +480,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "Uhrn5znOWx7k",
    "metadata": {
     "id": "Uhrn5znOWx7k"
    },
@@ -511,7 +496,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "UBfeudg_Wx7i",
    "metadata": {
     "id": "UBfeudg_Wx7i"
    },
@@ -524,7 +508,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "kAJgfSgoWx7j",
    "metadata": {
     "id": "kAJgfSgoWx7j"
    },
@@ -536,7 +519,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "pCzLLSreWx7q",
    "metadata": {
     "id": "pCzLLSreWx7q"
    },
@@ -549,7 +531,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "K9qarWJSWx7r",
    "metadata": {
     "id": "K9qarWJSWx7r"
    },
@@ -562,7 +543,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "0I8WspzkWx7r",
    "metadata": {
     "id": "0I8WspzkWx7r"
    },
@@ -575,7 +555,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "8nR1lNg7Wx7s",
    "metadata": {
     "id": "8nR1lNg7Wx7s"
    },
@@ -596,36 +575,35 @@
   },
   {
    "cell_type": "markdown",
-   "id": "WGG22i6w8Fzf",
    "metadata": {
     "id": "WGG22i6w8Fzf"
    },
    "source": [
     "#### Explanation of the outcome:\n",
     "\n",
-    "Attack Model Accuracy:\n",
-    "The attack model accuracy specifies how well the membership attack model performs in predicting if a given data point was used for training the target model. Since we have a two-class classification problem that the attack model solves (member or non-member), the lowest possible accuracy is 50% (random guessing for each sample). The best accuracy is at 100% if the model predicts every data point is sees right as member or non-member.\n",
+    "##### Attack Model Accuracy:\n",
+    "The attack model accuracy specifies how well the membership attack model performs in predicting if a given data point was used for training the target model. Since we have a two-class classification problem that the attack model solves (member or non-member), the lowest possible accuracy is 50%, which is equal to randomly guessing the class of a sample.  Theoretically, accuracy can also go below 50%, down to 0%. In this case, an inversion of the prediction of the labels can yield better results. E.g. if the accuracy is 40%, an inversion of the predicted labels yields 60% accuracy, hence 50% is considered the worst, or lowest possible accuracy. The best accuracy is at 100% if the model predicts every data point is sees right as member or non-member.\n",
     "\n",
-    "Train-Test-Gap (difference):\n",
-    "If your model has a train-test-gap larger than 5%, this could be a sign that your model overfits. Overfitting can be beneficial for successful membership inference attacks [1]. Therefore, you might want to reduce it by introducing regularization methods in your training, or using specific privacy methods [2,3], such as Differential Privacy [4]."
+    "##### Train-Test-Gap (difference):\n",
+    "If your model has a train-test-gap larger than 5%, this could be a sign that your model overfits. Overfitting can be beneficial for successful membership inference attacks [1]. Therefore, you might want to reduce it by introducing regularization methods in your training, or using specific privacy methods [2,3], such as Differential Privacy [4].\n",
+    "\n",
+    "(For References, please see last box)"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "NR2b6KWDMfGp",
    "metadata": {
     "id": "NR2b6KWDMfGp"
    },
    "source": [
     "#### Perpare attack analysis\n",
     "\n",
-    "Next, we prepare our attack analysis. To initialize our attack analysis we define the Membership Inference Attack method we want to perform (in this case we use the `MembershipInferenceBlackBoxRuleBasedAttack`) and the Attack Input Data. The Attack Input Data consists of two different sets. The first contains the data (`x_train`) and its corresponding labels (`y_train`) which were used to train the target model. The second contains the data (`x_test`) and its corresponding labels (`y_test`) which were not part of the training process of the target model."
+    "Next, we prepare our attack analysis. To initialize our attack analysis we define the Membership Inference Attack method we want to perform (in this case we use the `MembershipInferenceLabelOnlyDecisionBoundaryAttack`) and the Attack Input Data. The Attack Input Data consists of two different sets. The first contains the data (`x_train`) and its corresponding labels (`y_train`) which were used to train the target model. The second contains the data (`x_test`) and its corresponding labels (`y_test`) which were not part of the training process of the target model."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "hnl0pkYAMhtH",
    "metadata": {
     "id": "hnl0pkYAMhtH"
    },
@@ -644,20 +622,30 @@
   },
   {
    "cell_type": "markdown",
-   "id": "Cy-3bAKZMmwC",
    "metadata": {
     "id": "Cy-3bAKZMmwC"
    },
    "source": [
     "#### Define the slicing\n",
     "\n",
-    "Now we can define the slicing for our analysis. The slicing defines how the data will be sliced. Each slice will then be analysed by the attack separately, so see if the inference works better on certain parts of data than on others. "
+    "Now we can define the slicing for our analysis. The slicing defines how the data will be sliced. Each slice will then be analysed by the attack separately, so see if the inference works better on certain parts of data than on others.\n",
+    "\n",
+    "The types of slices can be chosen:\n",
+    "##### entire_dataset:\n",
+    "This options allows to pick the whole dataset as a single slice.\n",
+    "##### by_class:\n",
+    "If this option is chosen, the analysis will be done for each class individually, resulting in as many slices as there are classes.\n",
+    "##### by_classification_correctness:\n",
+    "If this option is chosen, two slices will be analyzed. The first slice is the set of all correctly classified samples, and the second slice is the set of all incorrectly classified samples.\n",
+    "\n",
+    "If all three choices are selected, a total of 3 + n slices will be analyzed, where n is the amount of classes of the dataset.\n",
+    "\n",
+    "For further information, please see the explanation of the outcome below the analysis."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "-M7Dm5YEMnya",
    "metadata": {
     "id": "-M7Dm5YEMnya"
    },
@@ -672,7 +660,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "iJvZGh0NMow9",
    "metadata": {
     "id": "iJvZGh0NMow9"
    },
@@ -685,7 +672,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9J1rEkl-MquD",
    "metadata": {
     "id": "9J1rEkl-MquD"
    },
@@ -704,7 +690,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "qGVKO2IwMqW5",
    "metadata": {
     "id": "qGVKO2IwMqW5"
    },
@@ -729,19 +714,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "-FxKrMksMwYN",
-   "metadata": {
-    "id": "-FxKrMksMwYN"
-   },
-   "source": [
-    "#### Compute privacy risk score\n",
-    "\n",
-    "As a next step, we want to compute the privacy risk scores. To do so, we input the target model and the data points which should be evaluated to the respective function. The given data points are separated into a train and tests set. The train set contains of the data (`x_train`) and its corresponding labels (`y_train`) which were used to train the target model. The test set contains the data (`x_test`) and its corresponding labels (`y_test`) which were not part of the training process of the target model. As a result, we get privacy risk scores for each data point, separated into train and test scores. The resulting values indicate the probability of a data point being a member or not."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "9j73m8k-9dDZ",
    "metadata": {
     "id": "9j73m8k-9dDZ"
    },
@@ -756,9 +728,7 @@
     "\n",
     "[5] Stacey Truex, Ling Liu, Mehmet Emre Gursoy, Lei Yu, and Wenqi Wei. 2019.Demystifying Membership Inference Attacks in Machine Learning as a Service.IEEE Transactions on Services Computing(2019)\n",
     "\n",
-    "[6] Suriyakumar, Vinith M., Nicolas Papernot, Anna Goldenberg, and Marzyeh Ghassemi. \"Chasing Your Long Tails: Differentially Private Prediction in Health Care Settings.\" In Proceedings of the 2021 ACM Conference on Fairness, Accountability, and Transparency, pp. 723-734. 2021.\n",
-    "\n",
-    "[7] Yunhui Long, Vincent Bindschaedler, Lei Wang, Diyue Bu, Xiaofeng Wang, HaixuTang, Carl A. Gunter, and Kai Chen. 2018.   Understanding Membership In-ferences on Well-Generalized Learning Models.CoRRabs/1802.04889 (2018).arXiv:1802.04889  http://arxiv.org/abs/1802.0\n"
+    "[6] Suriyakumar, Vinith M., Nicolas Papernot, Anna Goldenberg, and Marzyeh Ghassemi. \"Chasing Your Long Tails: Differentially Private Prediction in Health Care Settings.\" In Proceedings of the 2021 ACM Conference on Fairness, Accountability, and Transparency, pp. 723-734. 2021."
    ]
   }
  ],
@@ -787,7 +757,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.9"
+   "version": "3.8.5"
   },
   "widgets": {
    "application/vnd.jupyter.widget-state+json": {

--- a/notebooks/membership_inference_on_point_basis.ipynb
+++ b/notebooks/membership_inference_on_point_basis.ipynb
@@ -2,7 +2,6 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "Rf_QO8flWx6_",
    "metadata": {
     "id": "Rf_QO8flWx6_"
    },
@@ -12,7 +11,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "WKAYn2M4Wx7F",
    "metadata": {
     "id": "WKAYn2M4Wx7F"
    },
@@ -29,7 +27,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "Ia0VmlzeWx7H",
    "metadata": {
     "id": "Ia0VmlzeWx7H"
    },
@@ -37,12 +34,11 @@
     "\n",
     "## Overview\n",
     "\n",
-    "In this notebook, we want to show you how to use the `privacy-evaluator` tool to perform the Membership Inference Attacks On Point Basis also known as calculating the privacy risk score on both, a provided PyTorch and a provided Tensorflow model.\n"
+    "In this notebook, we want to show you how to use the `privacy-evaluator` tool to perform the Membership Inference Attacks On Point Basis also known as calculating the privacy risk score [1] on both, a provided PyTorch and a provided Tensorflow model.\n"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "DH6rB9KSWx7J",
    "metadata": {
     "id": "DH6rB9KSWx7J"
    },
@@ -55,7 +51,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "lNU7L3GCWx7M",
    "metadata": {
     "id": "lNU7L3GCWx7M"
    },
@@ -67,7 +62,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9d7ab468",
    "metadata": {
     "id": "9d7ab468",
     "scrolled": true
@@ -102,7 +96,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "mUH4YQ4tWx7Q",
    "metadata": {
     "id": "mUH4YQ4tWx7Q"
    },
@@ -114,7 +107,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b2da0876",
    "metadata": {
     "id": "b2da0876"
    },
@@ -126,7 +118,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "7aQIN6UMWx7W",
    "metadata": {
     "id": "7aQIN6UMWx7W"
    },
@@ -139,7 +130,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "fz4UuSxMWx7Y",
    "metadata": {
     "id": "fz4UuSxMWx7Y"
    },
@@ -156,7 +146,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "sv_fGg8jWx7S",
    "metadata": {
     "id": "sv_fGg8jWx7S"
    },
@@ -169,7 +158,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "dcae11d8",
    "metadata": {
     "id": "dcae11d8"
    },
@@ -181,14 +169,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "76a432f6",
    "metadata": {
     "id": "76a432f6"
    },
    "source": [
     "#### Perform Membership Attack on Point Basis\n",
     "\n",
-    "Next, we want to perform a Membership Inference Attack on Point Basis its output is also known as Privacy Risk Score. In this case, we do not need to fit the attack because this approach depends only on the attacked the loss calculation of the data points and the target model.\n",
+    "Next, we want to perform a Membership Inference Attack on Point Basis its output is also known as Privacy Risk Score [1]. In this case, we do not need to fit the attack because this approach depends only on the attacked the loss calculation of the data points and the target model.\n",
     "\n",
     "To do so, we input the target model and the data points which should be evaluated to the respective function. The given data points are separated into a train and tests set. The train set contains of the data (`x_train`) and its corresponding labels (`y_train`) which were used to train the target model. The test set contains the data (`x_test`) and its corresponding labels (`y_test`) which were not part of the training process of the target model. As a result, we get privacy risk scores for each data point, separated into train and test scores. The resulting values indicate the probability of a data point being a member or not."
    ]
@@ -196,7 +183,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "GzT8PRx3EIVc",
    "metadata": {
     "id": "GzT8PRx3EIVc"
    },
@@ -209,7 +195,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "CQdBbr5CEKo6",
    "metadata": {
     "id": "CQdBbr5CEKo6"
    },
@@ -222,7 +207,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "EEjwlA03ELD6",
    "metadata": {
     "id": "EEjwlA03ELD6"
    },
@@ -237,7 +221,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "fgz5fsp0EOTO",
    "metadata": {
     "id": "fgz5fsp0EOTO"
    },
@@ -248,7 +231,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "tvSypW8HEOzv",
    "metadata": {
     "id": "tvSypW8HEOzv"
    },
@@ -260,7 +242,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "0-zzVnlbERPK",
    "metadata": {
     "id": "0-zzVnlbERPK"
    },
@@ -271,7 +252,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "78e80HEmERr7",
    "metadata": {
     "id": "78e80HEmERr7"
    },
@@ -283,7 +263,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "aPdWNxlgFOyU",
    "metadata": {
     "id": "aPdWNxlgFOyU"
    },
@@ -291,7 +270,9 @@
     "#### Explanation of the outcome:\n",
     "\n",
     "##### Vulnerability of individual data points:\n",
-    "The training data points that exhibit an increased membership privacy risk might differ from their classes mean samples (outliers) [7]. You could check them again, see if they have the correct label, or if they exhibit any non-standard properties for the class. If so, correct them. It was also shown that points with an high influence on the decision boundary are more vulnerable to membership inference attacks [5]. Therefore, these points might be important. If you want to protect them, you might add several similar training samples as they are to the class. \n",
+    "The privacy risk score is an individual sample’s likelihood of being a training member, which allows an adversary to identify samples with high privacy risks and perform membership inference attacks with high confidence [1].\n",
+    "\n",
+    "The training data points that exhibit an increased membership privacy risk might differ from their classes mean samples (outliers) [2]. You could check them again, see if they have the correct label, or if they exhibit any non-standard properties for the class. If so, correct them. It was also shown that points with an high influence on the decision boundary are more vulnerable to membership inference attacks [3]. Therefore, these points might be important. If you want to protect them, you might add several similar training samples as they are to the class. \n",
     "\n",
     "\n",
     "(For References, please see last box)"
@@ -299,7 +280,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "xG4nYKGzWx7i",
    "metadata": {
     "id": "xG4nYKGzWx7i"
    },
@@ -311,7 +291,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "_7ty54AKWx7k",
    "metadata": {
     "id": "_7ty54AKWx7k"
    },
@@ -324,7 +303,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "Uhrn5znOWx7k",
    "metadata": {
     "id": "Uhrn5znOWx7k"
    },
@@ -341,7 +319,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "UBfeudg_Wx7i",
    "metadata": {
     "id": "UBfeudg_Wx7i"
    },
@@ -354,7 +331,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "kAJgfSgoWx7j",
    "metadata": {
     "id": "kAJgfSgoWx7j"
    },
@@ -366,14 +342,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "cmEM23LTEpmo",
    "metadata": {
     "id": "cmEM23LTEpmo"
    },
    "source": [
     "#### Perform Membership Attack on Point Basis\n",
     "\n",
-    "Next, we want to perform a Membership Inference Attack on Point Basis its output also known as Privacy Risk Score. In this case, we do not need to fit the attack because this approach depends only on the attacked the loss calculation of the data points and the target model.\n",
+    "Next, we want to perform a Membership Inference Attack on Point Basis its output also known as Privacy Risk Score [1]. In this case, we do not need to fit the attack because this approach depends only on the attacked the loss calculation of the data points and the target model.\n",
     "\n",
     "To do so, we input the target model and the data points which should be evaluated to the respective function. The given data points are separated into a train and tests set. The train set contains of the data (`x_train`) and its corresponding labels (`y_train`) which were used to train the target model. The test set contains the data (`x_test`) and its corresponding labels (`y_test`) which were not part of the training process of the target model. As a result, we get privacy risk scores for each data point, separated into train and test scores. The resulting values indicate the probability of a data point being a member or not."
    ]
@@ -381,7 +356,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "tD9B3Es2EsEc",
    "metadata": {
     "id": "tD9B3Es2EsEc"
    },
@@ -394,7 +368,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "4LzAETqNEtmf",
    "metadata": {
     "id": "4LzAETqNEtmf"
    },
@@ -407,7 +380,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "f6Se9E15Evx2",
    "metadata": {
     "id": "f6Se9E15Evx2"
    },
@@ -422,7 +394,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "6IdryTLMExbv",
    "metadata": {
     "id": "6IdryTLMExbv"
    },
@@ -433,7 +404,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "Y_OzKCPhEx6V",
    "metadata": {
     "id": "Y_OzKCPhEx6V"
    },
@@ -445,7 +415,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "AAtwXb71Ey0_",
    "metadata": {
     "id": "AAtwXb71Ey0_"
    },
@@ -456,7 +425,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "Z-ImMLkyEzG0",
    "metadata": {
     "id": "Z-ImMLkyEzG0"
    },
@@ -468,7 +436,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "3ToJNWK5Fjzg",
    "metadata": {
     "id": "3ToJNWK5Fjzg"
    },
@@ -476,7 +443,9 @@
     "#### Explanation of the outcome:\n",
     "\n",
     "##### Vulnerability of individual data points:\n",
-    "The training data points that exhibit an increased membership privacy risk might differ from their classes mean samples (outliers) [7]. You could check them again, see if they have the correct label, or if they exhibit any non-standard properties for the class. If so, correct them. It was also shown that points with an high influence on the decision boundary are more vulnerable to membership inference attacks [5]. Therefore, these points might be important. If you want to protect them, you might add several similar training samples as they are to the class. \n",
+    "The privacy risk score is an individual sample’s likelihood of being a training member, which allows an adversary to identify samples with high privacy risks and perform membership inference attacks with high confidence [1].\n",
+    "\n",
+    "The training data points that exhibit an increased membership privacy risk might differ from their classes mean samples (outliers) [2]. You could check them again, see if they have the correct label, or if they exhibit any non-standard properties for the class. If so, correct them. It was also shown that points with an high influence on the decision boundary are more vulnerable to membership inference attacks [3]. Therefore, these points might be important. If you want to protect them, you might add several similar training samples as they are to the class. \n",
     "\n",
     "\n",
     "(For References, please see last box)"
@@ -484,35 +453,16 @@
   },
   {
    "cell_type": "markdown",
-   "id": "LjKjKcOtFple",
    "metadata": {
     "id": "LjKjKcOtFple"
    },
    "source": [
-    "[1]S. Yeom, I. Giacomelli, M. Fredrikson, and S. Jha. \\Privacy Risk in Machine Learning: Analyzing the Connection to Overfitting\". In: 2018 IEEE 31st Computer Security Foundations Symposium (CSF). July 2018, pp. 268{282. doi:10.1109/CSF.2018.00027.\n",
+    "[1] Song, Liwei and Prateek Mittal. “Systematic Evaluation of Privacy Risks of Machine Learning Models.” ArXiv abs/2003.10595 (2020): n. pag.\n",
     "\n",
-    "[2] Reza Shokri, Marco Stronati, Congzheng Song, and Vitaly Shmatikov. 2017. Mem-bership Inference Attacks Against Machine Learning Models. In2017 IEEE Sym-posium on Security and Privacy (SP). 3–18.\n",
+    "[2] Yunhui Long, Vincent Bindschaedler, Lei Wang, Diyue Bu, Xiaofeng Wang, HaixuTang, Carl A. Gunter, and Kai Chen. 2018.   Understanding Membership In-ferences on Well-Generalized Learning Models.CoRRabs/1802.04889 (2018).arXiv:1802.04889  http://arxiv.org/abs/1802.0\n",
     "\n",
-    "[3] Milad Nasr, Reza Shokri, and Amir Houmansadr. 2018. Machine Learning withMembership Privacy Using Adversarial Regularization. InProceedings of the 2018ACM SIGSAC Conference on Computer and Communications Security(Toronto,Canada)(CCS ’18). Association for Computing Machinery, New York, NY, USA,634–64\n",
-    "\n",
-    "[4] Cynthia Dwork. 2006.  Differential Privacy. InAutomata, Languages and Pro-gramming, Michele Bugliesi, Bart Preneel, Vladimiro Sassone, and Ingo Wegener(Eds.). Springer Berlin Heidelberg, Berlin, Heidelberg\n",
-    "\n",
-    "[5] Stacey Truex, Ling Liu, Mehmet Emre Gursoy, Lei Yu, and Wenqi Wei. 2019.Demystifying Membership Inference Attacks in Machine Learning as a Service.IEEE Transactions on Services Computing(2019)\n",
-    "\n",
-    "[6] Suriyakumar, Vinith M., Nicolas Papernot, Anna Goldenberg, and Marzyeh Ghassemi. \"Chasing Your Long Tails: Differentially Private Prediction in Health Care Settings.\" In Proceedings of the 2021 ACM Conference on Fairness, Accountability, and Transparency, pp. 723-734. 2021.\n",
-    "\n",
-    "[7] Yunhui Long, Vincent Bindschaedler, Lei Wang, Diyue Bu, Xiaofeng Wang, HaixuTang, Carl A. Gunter, and Kai Chen. 2018.   Understanding Membership In-ferences on Well-Generalized Learning Models.CoRRabs/1802.04889 (2018).arXiv:1802.04889  http://arxiv.org/abs/1802.0\n"
+    "[3] Stacey Truex, Ling Liu, Mehmet Emre Gursoy, Lei Yu, and Wenqi Wei. 2019.Demystifying Membership Inference Attacks in Machine Learning as a Service.IEEE Transactions on Services Computing(2019)"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "V2w1YZGEFqH5",
-   "metadata": {
-    "id": "V2w1YZGEFqH5"
-   },
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {
@@ -540,7 +490,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.10"
+   "version": "3.8.5"
   }
  },
  "nbformat": 4,

--- a/privacy_evaluator/attacks/membership_inference/black_box.py
+++ b/privacy_evaluator/attacks/membership_inference/black_box.py
@@ -5,7 +5,10 @@ from ...classifiers.classifier import Classifier
 
 
 class MembershipInferenceBlackBoxAttack(MembershipInferenceAttack):
-    """MembershipInferenceBlackBoxAttack class."""
+    """MembershipInferenceBlackBoxAttack class.
+
+    For information about this attacks outcome, please see to membership_inference.py.
+    """
 
     _ART_MEMBERSHIP_INFERENCE_ATTACK_CLASS = "MembershipInferenceBlackBox"
 

--- a/privacy_evaluator/attacks/membership_inference/black_box_rule_based.py
+++ b/privacy_evaluator/attacks/membership_inference/black_box_rule_based.py
@@ -3,7 +3,10 @@ from ...classifiers.classifier import Classifier
 
 
 class MembershipInferenceBlackBoxRuleBasedAttack(MembershipInferenceAttack):
-    """MembershipInferenceBlackBoxRuleBasedAttack class."""
+    """MembershipInferenceBlackBoxRuleBasedAttack class.
+
+    For information about this attacks outcome, please see to membership_inference.py.
+    """
 
     _ART_MEMBERSHIP_INFERENCE_ATTACK_CLASS = "MembershipInferenceBlackBoxRuleBased"
 

--- a/privacy_evaluator/attacks/membership_inference/label_only_decision_boundary.py
+++ b/privacy_evaluator/attacks/membership_inference/label_only_decision_boundary.py
@@ -5,7 +5,10 @@ from ...classifiers.classifier import Classifier
 
 
 class MembershipInferenceLabelOnlyDecisionBoundaryAttack(MembershipInferenceAttack):
-    """MembershipInferenceLabelOnlyDecisionBoundaryAttack class."""
+    """MembershipInferenceLabelOnlyDecisionBoundaryAttack class.
+
+    For information about this attacks outcome, please see to membership_inference.py.
+    """
 
     _ART_MEMBERSHIP_INFERENCE_ATTACK_CLASS = "LabelOnlyDecisionBoundary"
 

--- a/privacy_evaluator/attacks/membership_inference/membership_inference.py
+++ b/privacy_evaluator/attacks/membership_inference/membership_inference.py
@@ -21,13 +21,16 @@ class MembershipInferenceAttack(Attack):
     Attack Model Accuracy:
     The attack model accuracy specifies how well the membership attack model performs in predicting if a given data
     point was used for training the target model. Since we have a two-class classification problem that the attack model
-    solves (member or non-member), the lowest possible accuracy is 50% (random guessing for each sample). The best
-    accuracy is at 100% if the model predicts every data point is sees right as member or non-member.
+    solves (member or non-member), the lowest possible accuracy is 50%, which is equal to randomly guessing the class of
+    a sample.  Theoretically, accuracy can also go below 50%, down to 0%. In this case, an inversion of the prediction
+    of the labels can yield better results. E.g. if the accuracy is 40%, an inversion of the predicted labels yields 60%
+    accuracy, hence 50% is considered the worst, or lowest possible accuracy. The best accuracy is at 100% if the model
+    predicts every data point is sees right as member or non-member.
 
     Train-Test-Gap (difference):
     If your model has a train-test-gap larger than 5%, this could be a sign that your model overfits. Overfitting can be
     beneficial for successful membership inference attacks [1]. Therefore, you might want to reduce it by introducing
-    regularization methods in your training, or using specific privacy methods[2,3], such as Differential Privacy [4].
+    regularization methods in your training, or using specific privacy methods [2,3], such as Differential Privacy [4].
 
     [1]S. Yeom, I. Giacomelli, M. Fredrikson, and S. Jha. \Privacy Risk in Machine Learning: Analyzing the Connection
     to Overfitting". In: 2018 IEEE 31st Computer Security Foundations Symposium (CSF). July 2018, pp. 268{282.

--- a/privacy_evaluator/attacks/membership_inference/membership_inference_analysis.py
+++ b/privacy_evaluator/attacks/membership_inference/membership_inference_analysis.py
@@ -17,7 +17,7 @@ class MembershipInferenceAttackAnalysis:
     Interpretation of Outcome:
 
     Advantage Score:
-    The attacker advantageis a score that relies on comparing the model output on member and non-member data points.
+    The attacker advantage is a score that relies on comparing the model output on member and non-member data points.
     The model outputs are probability values over all classes, and they are often different on member and non-member
     data points. Usually, the model is more confident on member data points, because it has seen them during training.
     When trying to find a threshold value to tell apart member and non-member samples by their different model outputs,
@@ -36,11 +36,12 @@ class MembershipInferenceAttackAnalysis:
     Specific classes can be differently vulnerable. It may seem that the membership inference attack is more successful
     on some classes than on the other classes. Research has shown that the class distribution (and also the distribution
     of data points within one class) are factors that influence the vulnerability of a class for membership inference
-    attacks [1]. Also, small classes (belonging to minority groups) can be more prone to membership inference attacks[2].
-    One reason for this could be, that there is less data for that class, and therefore, the model overfits within this
-    class. It might make sense to look into the vulnerable classes of your model again, and maybe add more data to them,
-    use private synthetic data, or introduce privacy methods like Differential Privacy [2]. Attention, the use of
-    Differential Privacy could have a negative influence on the performance of your model for the minority classes.
+    attacks [1]. Also, small classes (belonging to minority groups) can be more prone to membership inference
+    attacks [2]. One reason for this could be, that there is less data for that class, and therefore, the model overfits
+    within this class. It might make sense to look into the vulnerable classes of your model again, and maybe add more
+    data to them, use private synthetic data, or introduce privacy methods like Differential Privacy [2]. Attention, the
+    use of Differential Privacy could have a negative influence on the performance of your model for the minority
+    classes.
 
     References:
     [1] Stacey Truex, Ling Liu, Mehmet Emre Gursoy, Lei Yu, and Wenqi Wei. 2019.Demystifying Membership Inference

--- a/privacy_evaluator/output/user_output_privacy_score.py
+++ b/privacy_evaluator/output/user_output_privacy_score.py
@@ -13,18 +13,23 @@ class UserOutputPrivacyScore(UserOutput):
     Interpretation of Outcome:
 
     Vulnerability of individual data points:
+    The privacy risk score is an individual sample’s likelihood of being a training member, which allows an adversary to
+    identify samples with high privacy risks and perform membership inference attacks with high confidence [1].
+
     The training data points that exhibit an increased membership privacy risk might differ from their classes mean
     samples (outliers) [2]. You could check them again, see if they have the correct label, or if they exhibit any
     non-standard properties for the class. If so, correct them. It was also shown that points with an high influence on
-    the decision boundary are more vulnerable to membership inference attacks [1]. Therefore, these points might be
+    the decision boundary are more vulnerable to membership inference attacks [3]. Therefore, these points might be
     important. If you want to protect them, you might add several similar training samples as they are to the class.
 
     References:
-    [1] Stacey Truex, Ling Liu, Mehmet Emre Gursoy, Lei Yu, and Wenqi Wei. 2019.Demystifying Membership Inference
-    Attacks in Machine Learning as a Service.IEEE Transactions on Services Computing(2019)
+    [1] Song, Liwei and Prateek Mittal. “Systematic Evaluation of Privacy Risks of Machine Learning Models.” ArXiv
+    abs/2003.10595 (2020): n. pag
     [2] Yunhui Long, Vincent Bindschaedler, Lei Wang, Diyue Bu, Xiaofeng Wang, HaixuTang, Carl A. Gunter, and Kai Chen.
     2018.   Understanding Membership In-ferences on Well-Generalized Learning Models.CoRRabs/1802.04889
     (2018).arXiv:1802.04889  http://arxiv.org/abs/1802.0
+    [3] Stacey Truex, Ling Liu, Mehmet Emre Gursoy, Lei Yu, and Wenqi Wei. 2019.Demystifying Membership Inference
+    Attacks in Machine Learning as a Service.IEEE Transactions on Services Computing(2019)
     """
 
     def __init__(self, attack_data_y: np.ndarray, privacy_risk: np.ndarray):


### PR DESCRIPTION
#192 Change 'lowest possible' accuracy to 'baseline' accuracy in accuracy description
- So, apparently we already elaborated that lowest possible accuracy of 50% is random guessing. I explained it further by stating an example that for accuracy below 50%, if you invert the predictions, you get accuracy above 50%. If someone does not understand the previous elaboration, then changing “lowest accuracy” to “baseline accuracy” won’t help either, i assumed.
I changed it in both, in the notebooks as well as the docstrings
- Put references to the outcome interpretations in each of the attacks doc strings, referencing the main attack class “membership_inference.py”. 
- Removed redundant references at the bottom of the notebooks (and renumbered the references, hopefully without mistakes – please pay attention to stuff like this when we finalize the project). 

#197 explain risk scores further (e.g. high -> not good)
- Added reference to the paper of the privacy risk score to the corresponding notebook in 3 locations (first sentence/introduction, and twice at “[...] point basis output known as Privacy Risk Score [...]”)
- Added a sentence to privacy risk score outcome explanation, stating what the (high) score indicates for an adversary. (notebook and docstring of user_output_privacy_score.py).

#193 explain slicing properly in notebook with output
- Added a tiny explanation of what the 3 boolean slicing variables mean and how many slices to expect.
- I think we are still changing the output, so I will look into explaining the output better, once its finalized

Other:
- Fixed some typo
- Fixed some reference (e.g. [2]) spacing
- Removed some leftover cell which wasn't deleted previously